### PR TITLE
disable .set mips2 for mips release r6

### DIFF
--- a/include/boost/smart_ptr/detail/sp_counted_base_gcc_mips.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_gcc_mips.hpp
@@ -38,7 +38,9 @@ inline void atomic_increment( int * pw )
     (
         "0:\n\t"
         ".set push\n\t"
+#if !defined(__mips_isa_rev) || (__mips_isa_rev < 6)
         ".set mips2\n\t"
+#endif
         "ll %0, %1\n\t"
         "addiu %0, 1\n\t"
         "sc %0, %1\n\t"
@@ -59,7 +61,9 @@ inline int atomic_decrement( int * pw )
     (
         "0:\n\t"
         ".set push\n\t"
+#if !defined(__mips_isa_rev) || (__mips_isa_rev < 6)
         ".set mips2\n\t"
+#endif
         "ll %1, %2\n\t"
         "addiu %0, %1, -1\n\t"
         "sc %0, %2\n\t"
@@ -85,7 +89,9 @@ inline int atomic_conditional_increment( int * pw )
     (
         "0:\n\t"
         ".set push\n\t"
+#if !defined(__mips_isa_rev) || (__mips_isa_rev < 6)
         ".set mips2\n\t"
+#endif
         "ll %0, %2\n\t"
         "beqz %0, 1f\n\t"
         "addiu %1, %0, 1\n\t"


### PR DESCRIPTION
MIPS r6 changed the encoding for `ll' instruction,
if we `.set mips2', it will generate the old encoding for `ll'.

So here we disable it for r6.